### PR TITLE
Run process in background

### DIFF
--- a/conanplugin.cpp
+++ b/conanplugin.cpp
@@ -74,8 +74,14 @@ namespace conan {
       _conanBin.waitForStarted();
 
       _progress = std::make_unique< QFutureInterface< void > >();
+
+#if QTCREATOR_MAJOR == 4 && QTCREATOR_MINOR <= 12
+      const auto id = Core::Id("qconan");
+#else
+      const auto id = Utils::Id("qconan");
+#endif
       const auto progress = Core::ProgressManager::addTask(
-          _progress->future(), "conan install", Utils::Id("qconan"));
+          _progress->future(), "conan install", id);
       QObject::connect(progress, &Core::FutureProgress::canceled, this,
           [this] { _conanBin.kill(); });
       _progress->setProgressRange(0, 100);

--- a/conanplugin.h
+++ b/conanplugin.h
@@ -4,6 +4,7 @@
 #include "conan_global.h"
 #include <QDir>
 #include <QFileSystemWatcher>
+#include <QProcess>
 #include <extensionsystem/iplugin.h>
 #include <projectexplorer/projecttree.h>
 
@@ -12,11 +13,6 @@ namespace ProjectExplorer {
   class EnvironmentAspect;
   class Target;
 } // namespace ProjectExplorer
-
-namespace Utils {
-  class SynchronousProcessResponse;
-  class SynchronousProcess;
-} // namespace Utils
 
 namespace conan {
   namespace Internal {
@@ -64,14 +60,12 @@ namespace conan {
       ProjectExplorer::EnvironmentAspect* runEnvironmentAspect() const;
 
     private:
+      void onInstallFinished(int exitCode, QProcess::ExitStatus exitStatus);
       void loadProjectConfiguration(const ProjectExplorer::Project* project);
 
       void write(const QString& text) const;
 
       static ProjectExplorer::Target* currentTarget();
-      static Utils::SynchronousProcessResponse runBlocking(
-          Utils::SynchronousProcess& process, const QString& exe,
-          const QStringList& args);
 
       QString currentBuildDir() const;
 
@@ -80,6 +74,7 @@ namespace conan {
       PluginConfig _config;
 
     private:
+      QProcess _conanBin;
       QString _lastInstallDir;
       QFileSystemWatcher _conanFileWatcher;
       QFileSystemWatcher _settingsFileWatcher;

--- a/conanplugin.h
+++ b/conanplugin.h
@@ -4,6 +4,7 @@
 #include "conan_global.h"
 #include <QDir>
 #include <QFileSystemWatcher>
+#include <QFutureInterface>
 #include <QProcess>
 #include <extensionsystem/iplugin.h>
 #include <projectexplorer/projecttree.h>
@@ -74,6 +75,7 @@ namespace conan {
       PluginConfig _config;
 
     private:
+      std::unique_ptr< QFutureInterface< void > > _progress;
       QProcess _conanBin;
       QString _lastInstallDir;
       QFileSystemWatcher _conanFileWatcher;

--- a/conanplugin.h
+++ b/conanplugin.h
@@ -7,6 +7,7 @@
 #include <QFutureInterface>
 #include <QProcess>
 #include <extensionsystem/iplugin.h>
+#include <memory>
 #include <projectexplorer/projecttree.h>
 
 class BuildInfo;


### PR DESCRIPTION
Execute the conan install command in the background and keep the user informed. Also, provide a cancelation option to the user. To improve also error cases, the user is informed about unexpected return values from conan install, which happens if there is a python error and also if something went during the dependency handling, e.g.: package reference unknown or package reference not available due to different used settings.

Background Information:
In case packages are not available inside of the conan cache, packages may be downloaded from remote sites which takes a lot of time. To keep the user informed about a long-running activity, the default progress bar on the bottom right is shown. Sometimes such an operation takes too much time and the user would like to abort the operation which is now also possible.