### PR TITLE
Run process in background

### DIFF
--- a/BuildInfo.cpp
+++ b/BuildInfo.cpp
@@ -1,4 +1,5 @@
 #include "BuildInfo.h"
+#include <QDir>
 #include <QFile>
 #include <QJsonDocument>
 #include <QJsonObject>
@@ -81,8 +82,11 @@ QStringList BuildInfo::dependenciesToStringList(const QString key) const
     foreach (const auto& depObj, depList)
     {
       auto variantList = depObj.toMap().value(key).toList();
-      std::for_each(variantList.begin(), variantList.end(),
-          [&result](const auto& el) { result.push_back(el.toString()); });
+      std::for_each(
+          variantList.begin(), variantList.end(), [&result](const auto& el) {
+            result.push_back(QDir::toNativeSeparators(
+                QDir::cleanPath(el.toString().replace("\\", "/"))));
+          });
     }
   }
   return result;

--- a/conanplugin.cpp
+++ b/conanplugin.cpp
@@ -339,7 +339,7 @@ namespace conan {
           foreach (const auto& path, appendPath)
           {
             auto envItem = Utils::EnvironmentItem(
-                QStringLiteral("PATH"), path, Utils::NameValueItem::Append);
+                QStringLiteral("PATH"), path, Utils::NameValueItem::Prepend);
             newPaths.push_back(envItem);
             write(tr("Add path to env >%1<").arg(path));
           }

--- a/unittest/tst_buildinfotest.cpp
+++ b/unittest/tst_buildinfotest.cpp
@@ -117,6 +117,54 @@ private slots:
           << BuildInfo(root) << QStringList()
           << QStringList({"dep1_test", "dep1_test", "dep2_test", "dep2_test"});
     }
+    {
+      QVariantMap dep1;
+      dep1.insert(
+          "lib_paths", QVariant::fromValue(QList< QVariant >(
+                           {QDir::toNativeSeparators("src/../dep1_test")})));
+      dep1.insert("bin_paths", QVariant::fromValue(QList< QVariant >()));
+
+      QList< QVariant > deps = {dep1};
+
+      QVariantMap root;
+      root.insert("dependencies", deps);
+      root.insert("deps_env_info", QVariantMap());
+
+      QTest::newRow("relativeLib")
+          << BuildInfo(root) << QStringList("dep1_test") << QStringList();
+    }
+    {
+      QVariantMap dep1;
+      dep1.insert(
+          "bin_paths", QVariant::fromValue(QList< QVariant >(
+                           {QDir::toNativeSeparators("src/../dep1_test")})));
+      dep1.insert("lib_paths", QVariant::fromValue(QList< QVariant >()));
+
+      QList< QVariant > deps = {dep1};
+
+      QVariantMap root;
+      root.insert("dependencies", deps);
+      root.insert("deps_env_info", QVariantMap());
+
+      QTest::newRow("relativeBin")
+          << BuildInfo(root) << QStringList() << QStringList("dep1_test");
+    }
+    {
+      QVariantMap dep1;
+      dep1.insert("bin_paths", QVariant::fromValue(QList< QVariant >(
+                                   {R"_(src\dep1_test/include)_"})));
+      dep1.insert("lib_paths", QVariant::fromValue(QList< QVariant >()));
+
+      QList< QVariant > deps = {dep1};
+
+      QVariantMap root;
+      root.insert("dependencies", deps);
+      root.insert("deps_env_info", QVariantMap());
+
+      QTest::newRow("mixedPaths")
+          << BuildInfo(root) << QStringList()
+          << QStringList(QDir::toNativeSeparators("src/dep1_test/include"));
+    }
   }
 
   void testDataStructure()


### PR DESCRIPTION
On Windows, the special cases with mixed paths (e.g. c:\folder/other) are not working with QtCreator 4.12.0. Therefore, this PR takes care of unifying the paths. 